### PR TITLE
Fix: correct Kiwibank enum wire value (BDL-1261)

### DIFF
--- a/java-spring6/src/main/java/nz/co/blink/debit/dto/v1/Bank.java
+++ b/java-spring6/src/main/java/nz/co/blink/debit/dto/v1/Bank.java
@@ -40,7 +40,7 @@ public enum Bank {
 
     WESTPAC("Westpac"),
 
-    KIWIBANK("KiwiBank"),
+    KIWIBANK("Kiwibank"),
 
     CYBERSOURCE("Cybersource"),
 

--- a/java-spring6/src/test/java/nz/co/blink/debit/dto/v1/BankTest.java
+++ b/java-spring6/src/test/java/nz/co/blink/debit/dto/v1/BankTest.java
@@ -1,0 +1,56 @@
+package nz.co.blink.debit.dto.v1;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import nz.co.blink.debit.exception.BlinkInvalidValueException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Verifies the {@link Bank} enum wire values, in particular the Kiwibank fix (BDL-1261).
+ */
+class BankTest {
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+    }
+
+    // ===== Kiwibank wire value (BDL-1261) =====
+
+    @Test
+    void testKiwibankSerialisesToCorrectWireValue() throws Exception {
+        assertThat(objectMapper.writeValueAsString(Bank.KIWIBANK)).isEqualTo("\"Kiwibank\"");
+    }
+
+    @Test
+    void testKiwibankToStringReturnsCorrectWireValue() {
+        assertThat(Bank.KIWIBANK.toString()).isEqualTo("Kiwibank");
+    }
+
+    @Test
+    void testKiwibankDeserialisesFromCorrectWireValue() throws Exception {
+        assertThat(objectMapper.readValue("\"Kiwibank\"", Bank.class)).isEqualTo(Bank.KIWIBANK);
+    }
+
+    @Test
+    void testFromValueResolvesCorrectWireValue() throws BlinkInvalidValueException {
+        assertThat(Bank.fromValue("Kiwibank")).isEqualTo(Bank.KIWIBANK);
+    }
+
+    @Test
+    void testFromValueResolvesConstantName() throws BlinkInvalidValueException {
+        // Domain-model (entity) lookups match on the constant name; unaffected by the wire value change
+        assertThat(Bank.fromValue("KIWIBANK")).isEqualTo(Bank.KIWIBANK);
+    }
+
+    @Test
+    void testFromValueRejectsOldWireValue() {
+        assertThatThrownBy(() -> Bank.fromValue("KiwiBank"))
+                .isInstanceOf(BlinkInvalidValueException.class);
+    }
+}

--- a/java-v2/src/main/java/nz/co/blink/debit/dto/v1/Bank.java
+++ b/java-v2/src/main/java/nz/co/blink/debit/dto/v1/Bank.java
@@ -42,7 +42,7 @@ public enum Bank {
   
   WESTPAC("Westpac"),
   
-  KIWI_BANK("KiwiBank"),
+  KIWI_BANK("Kiwibank"),
   
   PNZ("PNZ"),
   

--- a/java-v2/src/test/java/nz/co/blink/debit/dto/v1/BankTest.java
+++ b/java-v2/src/test/java/nz/co/blink/debit/dto/v1/BankTest.java
@@ -1,0 +1,49 @@
+package nz.co.blink.debit.dto.v1;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Verifies the {@link Bank} enum wire values, in particular the Kiwibank fix (BDL-1261).
+ */
+class BankTest {
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+    }
+
+    // ===== Kiwibank wire value (BDL-1261) =====
+
+    @Test
+    void testKiwibankSerialisesToCorrectWireValue() throws Exception {
+        assertThat(objectMapper.writeValueAsString(Bank.KIWI_BANK)).isEqualTo("\"Kiwibank\"");
+    }
+
+    @Test
+    void testKiwibankGetValueReturnsCorrectWireValue() {
+        assertThat(Bank.KIWI_BANK.getValue()).isEqualTo("Kiwibank");
+    }
+
+    @Test
+    void testKiwibankDeserialisesFromCorrectWireValue() throws Exception {
+        assertThat(objectMapper.readValue("\"Kiwibank\"", Bank.class)).isEqualTo(Bank.KIWI_BANK);
+    }
+
+    @Test
+    void testFromValueResolvesCorrectWireValue() {
+        assertThat(Bank.fromValue("Kiwibank")).isEqualTo(Bank.KIWI_BANK);
+    }
+
+    @Test
+    void testFromValueRejectsOldWireValue() {
+        assertThatThrownBy(() -> Bank.fromValue("KiwiBank"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
Change the Bank enum wire value from "KiwiBank" to "Kiwibank" in both SDK artifacts to match the Blink Debit API.

- java-spring6: KIWIBANK("KiwiBank") -> KIWIBANK("Kiwibank")
- java-v2: KIWI_BANK("KiwiBank") -> KIWI_BANK("Kiwibank")

For java-v2 (generated), only the value is hand-patched; the constant name KIWI_BANK is preserved to avoid a source-breaking rename for consumers. Add unit tests in both modules covering Jackson serialisation/deserialisation and fromValue lookups, including a negative test asserting the old "KiwiBank" value no longer resolves.